### PR TITLE
Kafka connector example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository stores a variety of examples demonstrating how to use the Oracle
 | [spatial](./spatial) | Spatial features examples |
 | [sql](./sql) | SQL examples |
 | [sqldeveloper](./sqldeveloper) | [SQL Developer](http://www.oracle.com/technetwork/developer-tools/sql-developer/) examples |
+| [txeventq](./txeventq) | TxEventQ examples |
 
 ## Documentation
 You can find the online documentation of the Oracle Database under [docs.oracle.com/en/database/](http://docs.oracle.com/en/database/)

--- a/txeventq/kafka-connector-example/README.md
+++ b/txeventq/kafka-connector-example/README.md
@@ -1,0 +1,71 @@
+# Oracle TxEventQ Connectors
+
+Repository for demonstrating how to use the Oracle TxEventQ Connectors. The repository will contain a Kafka client application 
+that will produce or consume from a specified Kafka topic. The Kafka client can be used to produce messages to a specifed Kafka
+topic. While the Kafka client is producing to the Kafka topic the Oracle TxEventQ Sink Connector can run and enqueue the messages
+from the specified Kafka topic into the specified TxEventQ. After the Oracle TxEventQ Sink Connector has completed enqueuing 
+messages from the Kafka topic, the Oracle TxEventQ Source Connector can be used to dequeue the messages from the specified 
+TxEventQ. While the Oracle TxEventQ is dequeuing messages into Kafka the specified Kafka topic, the Kafka client consumer
+be running to consume from that Kafka topic. 
+
+## Getting started
+
+To use the Oracle TxEventQ Connectors Kafka with a minimum version number of 3.1.0 will need to be downloaded and installed on 
+a server. Refer to [Kafka Apache](https://kafka.apache.org/) for information on how to start Kafka. The Oracle TxEventQ 
+Connectors requires a minimum Oracle Database version of 21c in order to create a Transactional Event Queue. Download the 
+[Oracle TxEventQ Connector](https://mvnrepository.com/artifact/com.oracle.database.messaging/txeventq-connector) from maven.
+Read the following [Readme](https://github.com/oracle/okafka/tree/master/connectors) file for how to setup and use the Oracle TxEventQ Connector.
+
+## Setting up database
+
+Clone the project from the repository. Open a bash window and change the directory to the location where the cloned project has been saved.
+
+Copy `initdb.sh.example` to `initdb.sh` and mark it as executable, i.e. `chmod a+x ./initdb.sh`
+
+Modify `initdb.sh` to fill in the hostname, port, name of the CDB, service domain, sys password, user, user password. The user and user
+password can be an existing user or a new user to create. To (re)initialize the database, run `./initdb.sh`
+
+The initdb.sh script will create a transactional event queue with the name of **TEQ** with the required privileges that is discussed in the 
+[Oracle TxEventQ Connector](https://mvnrepository.com/artifact/com.oracle.database.messaging/txeventq-connector) Readme. Use this queue
+name **TEQ** when creating the properties file for the Oracle TxEventQ Sink and Source Connector.
+
+**Note**: `sqlplus` is required and must be in your path.
+
+## Usage
+
+In the kafka_client\src\main\resources there are two properties file a config.properties and log4j.properties file that can can
+be modified if required.
+
+Start the Kafka broker by starting the zookeeper and Kafka server as described in the [Oracle TxEventQ Connector](https://mvnrepository.com/artifact/com.oracle.database.messaging/txeventq-connector) Readme.
+Create two different Kafka topics with 10 partitions one for the producer to use and one for the consumer to use.
+
+If running Kafka in a Windows environment open command prompt and change to the directory where Kafka has been installed.
+
+Run the following command to create a topic:
+
+```bash
+.\bin\windows\kafka-topics.bat --create --topic <name of topic> --bootstrap-server localhost:9092 --partitions 10
+```
+
+If running Kafka in a Linux environment open a terminal and change to the directory where Kafka has been installed.
+
+Run the following command in one of the terminals to start zookeeper:
+
+```bash
+bin/kafka-topics.sh --create --topic <name of topic> --bootstrap-server localhost:9092 --partitions 10
+```
+We will use the kafka_client to produce some messages to a specified topic and use the Oracle TxEventQ Sink Connector to enqueue
+the messages into the specified transactional event queue.
+
+Start the Oracle TxEventQ Sink Connector. Open a command prompt and change the directory to the kafka_client directory and run the
+following command `./runproducer.sh <name of kafka topic> <number of messages to produce>`.
+
+Next, we can use the kafka_client to consume messages from a specified topic that has been enqueued by the TxEventQ Source Connector.
+
+Stop the Oracle TxEventQ Sink Connector and start the Oracle TxEventQ Source Connector. Have the Oracle TxEventQ Source Connector
+dequeue messages from the transactional event queue that the Oracle TxEventQ Sink Connector just enqueued into and put into the specified
+Kafka topic. Open a command prompt and change the directory to the kafka_client directory and run the following 
+command `./runconsumer.sh <name of kafka topic>`. The name of the Kafka topic specified here should be the one the Source Connector is 
+dequeing into.
+
+

--- a/txeventq/kafka-connector-example/initdb.sh.example
+++ b/txeventq/kafka-connector-example/initdb.sh.example
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+HOST=<host>
+PORT=<portNum>
+
+# CDB 
+SERVICE=<serviceName>
+SERVICE_DOMAIN=<domain of service>
+
+# sys password
+SYSPASSWRD=<sys password>
+
+# Specify an existing user and password or a user and password that will be created.
+USER=<database user>
+USER_PWD=<database user password>
+
+sqlplus="sqlplus sys/${SYSPASSWRD}@'(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=${HOST})(PORT=${PORT})))(CONNECT_DATA=(SERVICE_NAME=${SERVICE}.${SERVICE_DOMAIN})(SERVER=DEDICATED)))' as sysdba @./sql/setupTeq.sql ${USER} ${USER_PWD}"
+
+echo quit | $sqlplus
+
+sqlplusTEQ="sqlplus ${USER}/${USER_PWD}@'(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=${HOST})(PORT=${PORT})))(CONNECT_DATA=(SERVICE_NAME=cdb1_pdb1.${SERVICE_DOMAIN})(SERVER=DEDICATED)))' @./sql/createTEQ.sql"
+
+echo quit | $sqlplusTEQ

--- a/txeventq/kafka-connector-example/kafka_client/pom.xml
+++ b/txeventq/kafka-connector-example/kafka_client/pom.xml
@@ -1,0 +1,70 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.oracle.kafka.teq</groupId>
+  <artifactId>kafka_client</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  
+   <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+  
+  <dependencies>
+   	<!-- https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients -->
+	<dependency>
+    	<groupId>org.apache.kafka</groupId>
+    	<artifactId>kafka-clients</artifactId>
+    	<version>3.4.0</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+	<dependency>
+    	<groupId>org.slf4j</groupId>
+    	<artifactId>slf4j-api</artifactId>
+    	<version>2.0.1</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12 -->
+	<dependency>
+    	<groupId>org.slf4j</groupId>
+    	<artifactId>slf4j-log4j12</artifactId>
+   	 	<version>2.0.1</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
+	<dependency>
+    	<groupId>org.apache.logging.log4j</groupId>
+    	<artifactId>log4j-api</artifactId>
+    	<version>2.18.0</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+	<dependency>
+    	<groupId>org.apache.logging.log4j</groupId>
+    	<artifactId>log4j-core</artifactId>
+    	<version>2.18.0</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
+	<dependency>
+    	<groupId>com.googlecode.json-simple</groupId>
+    	<artifactId>json-simple</artifactId>
+    	<version>1.1.1</version>
+	</dependency>
+	<dependency>
+    	<groupId>javax.json</groupId>
+    	<artifactId>javax.json-api</artifactId>
+    	<version>1.1.4</version>
+	</dependency>
+	<dependency>
+    	<groupId>com.github.javafaker</groupId>
+    	<artifactId>javafaker</artifactId>
+    	<version>1.0.2</version>
+	</dependency>
+	
+  </dependencies>
+</project>

--- a/txeventq/kafka-connector-example/kafka_client/runconsumer.sh
+++ b/txeventq/kafka-connector-example/kafka_client/runconsumer.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo compile...
+
+# pass <topicName> <numOfRecsToProduce> as args
+
+mvn -q clean compile exec:java \
+ -Dexec.mainClass="com.oracle.kafka.teq.Application" \
+ -Dexec.args="consumer $1"

--- a/txeventq/kafka-connector-example/kafka_client/runproducer.sh
+++ b/txeventq/kafka-connector-example/kafka_client/runproducer.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo compile...
+
+# pass <topicName> <numOfRecsToProduce> as args
+
+mvn -q clean compile exec:java \
+ -Dexec.mainClass="com.oracle.kafka.teq.Application" \
+ -Dexec.args="producer $1 $2"

--- a/txeventq/kafka-connector-example/kafka_client/src/main/java/com/oracle/kafka/teq/Application.java
+++ b/txeventq/kafka-connector-example/kafka_client/src/main/java/com/oracle/kafka/teq/Application.java
@@ -1,0 +1,34 @@
+package com.oracle.kafka.teq;
+
+import java.util.Locale;
+
+public class Application {
+
+	public static void main(String[] args) throws Exception {
+		String errorStr = "ERROR: Enter the first parameter as Producer or Consumer and specify the topic name as the second parameter.";
+
+		if (args.length < 1) {
+			System.out.println(errorStr);
+			return;
+		}
+
+		String mode = args[0];
+		String topicName = args[1];
+		int produceMsgCount = 0;
+		if (args.length > 2)
+			produceMsgCount = Integer.parseInt(args[2]);
+
+		switch (mode.toLowerCase(Locale.ROOT)) {
+		case "consumer":
+			System.out.println("Starting the Consumer\n");
+			new Consumer().runConsumer(topicName);
+			break;
+		case "producer":
+			System.out.println("Starting the Producer\n");
+			new Producer().runProducer(topicName, produceMsgCount);
+			break;
+		default:
+			System.out.println(errorStr);
+		}
+	}
+}

--- a/txeventq/kafka-connector-example/kafka_client/src/main/java/com/oracle/kafka/teq/Consumer.java
+++ b/txeventq/kafka-connector-example/kafka_client/src/main/java/com/oracle/kafka/teq/Consumer.java
@@ -1,0 +1,93 @@
+package com.oracle.kafka.teq;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.log4j.Logger;
+import org.json.simple.JSONObject;
+
+import java.util.*;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class Consumer {
+
+	private final int BLOCK_TIMEOUT_MS = 3000;
+	private KafkaConsumer<String, String> kafkaConsumer = null;
+	private final AtomicBoolean closed = new AtomicBoolean(false);
+
+	static Logger log = Logger.getLogger(Consumer.class.getName());
+
+	public Consumer() throws Exception {
+		Runtime.getRuntime().addShutdownHook(new Thread() {
+			@Override
+			public void run() {
+				try {
+					shutdown();
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		});
+	}
+
+	/**
+	 * Retrieves a collection of ConsumerRecords from the specified topic.
+	 *
+	 * @param topicName The topic to consume from
+	 * 
+	 * @throws Exception The Exception that will get thrown when an error occurs
+	 */
+	public void runConsumer(String topicName) throws Exception {
+		// keep running forever or until shutdown() is called from another thread.
+		try {
+			initiateKafkaConsumer().subscribe(List.of(topicName));
+			while (!closed.get()) {
+				ConsumerRecords<String, String> records = initiateKafkaConsumer()
+						.poll(Duration.ofMillis(BLOCK_TIMEOUT_MS));
+				if (records.count() == 0) {
+					log.info("No message to consume.");
+				}
+
+				for (ConsumerRecord<String, String> recordConsumed : records) {
+					HashMap<String, String> msgLogInfo = new HashMap<>();
+					msgLogInfo.put("topic", topicName);
+					msgLogInfo.put("key", recordConsumed.key());
+					msgLogInfo.put("message", recordConsumed.value());
+					log.info(new JSONObject(msgLogInfo).toJSONString());
+				}
+			}
+		} catch (WakeupException e) {
+			// Ignore exception if closing
+			if (!closed.get())
+				throw e;
+		}
+	}
+
+	/**
+	 * Shuts down the Kafka consumer that was initiated.
+	 * 
+	 * @throws Exception The Exception that will get thrown when an error occurs
+	 */
+	public void shutdown() throws Exception {
+		closed.set(true);
+		log.info("Consumer is shutting down.");
+		initiateKafkaConsumer().wakeup();
+	}
+
+	/**
+	 * Initiates the Kafka consumer.
+	 * 
+	 * @return The Kafka consumer that has been initiated.
+	 * @throws Exception The Exception that will get thrown when an error occurs
+	 */
+	private KafkaConsumer<String, String> initiateKafkaConsumer() throws Exception {
+		if (this.kafkaConsumer == null) {
+			Properties props = Utility.getProperties();
+			this.kafkaConsumer = new KafkaConsumer<>(props);
+		}
+		return this.kafkaConsumer;
+	}
+}

--- a/txeventq/kafka-connector-example/kafka_client/src/main/java/com/oracle/kafka/teq/Producer.java
+++ b/txeventq/kafka-connector-example/kafka_client/src/main/java/com/oracle/kafka/teq/Producer.java
@@ -1,0 +1,96 @@
+package com.oracle.kafka.teq;
+
+import java.util.UUID;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.util.HashMap;
+import java.util.Properties;
+
+import org.apache.log4j.Logger;
+import org.json.simple.JSONObject;
+
+public class Producer {
+
+	private KafkaProducer<String, String> kafkaProducer;
+	private final Logger log = Logger.getLogger(Producer.class.getName());
+
+	public Producer() throws Exception {
+		Runtime.getRuntime().addShutdownHook(new Thread() {
+			@Override
+			public void run() {
+				try {
+					shutdown();
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		});
+	}
+
+	/**
+	 * Produces a specified number of messages to the specified Kafka topic.
+	 *
+	 *
+	 * @param topicName     The name of the topic the message will be sent.
+	 * @param numOfMessages The number of random messages to send to the Kafka
+	 *                      topic.
+	 * @throws Exception The Exception that will get thrown when an error occurs
+	 */
+	public void runProducer(String topicName, int numOfMessages) throws Exception {
+		for (int i = 0; i < numOfMessages; i++) {
+			String key = UUID.randomUUID().toString();
+			// use the Message Helper to get a random string
+			String message = Utility.generateRandomMessage(i);
+			// send the message
+			this.sendMessage(topicName, key, message, null);
+			Thread.sleep(100);
+		}
+		this.shutdown();
+	}
+
+	/**
+	 * Sends a message to the specified Kafka topic.
+	 *
+	 * @param topicName The name of the topic to where the message will be sent
+	 * @param key       The key value for the message
+	 * @param message   The content of the message
+	 * @param partition The partition number to put the message in
+	 * @throws Exception The Exception that will get thrown when an error occurs
+	 */
+	protected void sendMessage(String topicName, String key, String message, Integer partition) throws Exception {
+		ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topicName, partition,
+				System.currentTimeMillis() / 1000, key, message);
+		HashMap<String, String> msgLogInfo = new HashMap<>();
+		msgLogInfo.put("topic", topicName);
+		msgLogInfo.put("key", key);
+		msgLogInfo.put("message", message);
+		log.debug(new JSONObject(msgLogInfo).toJSONString());
+		initiateKafkaProducer().send(producerRecord);
+	}
+
+	/**
+	 * Initiates the Kafka producer.
+	 * 
+	 * @return The Kafka producer that has been initiated.
+	 * @throws Exception The Exception that will get thrown when an error occurs
+	 */
+	private KafkaProducer<String, String> initiateKafkaProducer() throws Exception {
+		if (this.kafkaProducer == null) {
+			Properties props = Utility.getProperties();
+			this.kafkaProducer = new KafkaProducer<>(props);
+		}
+		return this.kafkaProducer;
+	}
+
+	/**
+	 * Closes the Kafka producer that was initiated.
+	 * 
+	 * @throws Exception The Exception that will get thrown when an error occurs
+	 */
+	public void shutdown() throws Exception {
+		log.info("Producer is shutting down");
+		initiateKafkaProducer().close();
+	}
+}

--- a/txeventq/kafka-connector-example/kafka_client/src/main/java/com/oracle/kafka/teq/Utility.java
+++ b/txeventq/kafka-connector-example/kafka_client/src/main/java/com/oracle/kafka/teq/Utility.java
@@ -1,0 +1,57 @@
+package com.oracle.kafka.teq;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Properties;
+
+import org.json.simple.JSONObject;
+
+import com.github.javafaker.Faker;
+
+public class Utility {
+	 
+	/**
+     * Gets a Properties information from the file src/main/resources/config.properties
+     *
+     * @return The Properties object
+     * @throws Exception Thrown if the file config.properties is not available
+     *                   in the directory src/main/resources
+     */
+    public static Properties getProperties() throws Exception {
+
+        Properties props = null;
+        try (InputStream input = Producer.class.getClassLoader().getResourceAsStream("config.properties")) {
+
+            props = new Properties();
+
+            if (input == null) {
+                throw new Exception("The configuration file config.properties could not be found.");
+            }
+            props.load(input);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+        
+        return props;
+    }
+    
+    /**
+     * Generates a random message to produce to a Kafka topic.
+     * 
+     * @param num The number to set for the message.
+     * @return The generated message.
+     */
+    public static String generateRandomMessage(int num) {
+    	Faker faker = new Faker();
+    	HashMap<String,String> fakeData = new HashMap<>();
+    	fakeData.put("Message Number", Integer.toString(num));
+    	fakeData.put("firstName", faker.name().firstName());
+    	fakeData.put("lastName", faker.name().lastName());
+    	fakeData.put("Job Skills", faker.job().keySkills());
+         
+    	return new JSONObject(fakeData).toString();
+    }
+
+
+}

--- a/txeventq/kafka-connector-example/kafka_client/src/main/resources/config.properties
+++ b/txeventq/kafka-connector-example/kafka_client/src/main/resources/config.properties
@@ -1,0 +1,23 @@
+# The location of the Kafka server
+bootstrap.servers=localhost:9092
+
+# the default group ID
+group.id=test-group
+
+# the default topic to use if one is not provided
+default.topic=magic-topic
+
+# The maximum number of records returned in a single call to poll()
+max.poll.records=10
+
+# If true the consumer's offset will be periodically committed in the background.
+enable.auto.commit=true
+
+# The frequency in milliseconds that the consumer offsets are auto-committed to Kafka if enable.auto.commit is set to true.
+auto.commit.interval.ms=500
+
+# classes for serializing and deserializing messages
+key.serializer=org.apache.kafka.common.serialization.StringSerializer
+value.serializer=org.apache.kafka.common.serialization.StringSerializer
+key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+value.deserializer=org.apache.kafka.common.serialization.StringDeserializer

--- a/txeventq/kafka-connector-example/kafka_client/src/main/resources/config.properties
+++ b/txeventq/kafka-connector-example/kafka_client/src/main/resources/config.properties
@@ -5,7 +5,7 @@ bootstrap.servers=localhost:9092
 group.id=test-group
 
 # the default topic to use if one is not provided
-default.topic=magic-topic
+default.topic=default-topic
 
 # The maximum number of records returned in a single call to poll()
 max.poll.records=10

--- a/txeventq/kafka-connector-example/kafka_client/src/main/resources/log4j.properties
+++ b/txeventq/kafka-connector-example/kafka_client/src/main/resources/log4j.properties
@@ -1,0 +1,16 @@
+# Root logger option
+log4j.rootLogger=info, file, stdout
+
+# Direct log messages to a log file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=logging.log
+log4j.appender.file.MaxFileSize=10MB
+log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/txeventq/kafka-connector-example/sql/createTEQ.sql
+++ b/txeventq/kafka-connector-example/sql/createTEQ.sql
@@ -1,0 +1,6 @@
+exec sys.dbms_aqadm.create_transactional_event_queue(queue_name=>'TEQ', multiple_consumers => TRUE); 
+exec sys.dbms_aqadm.set_queue_parameter('TEQ', 'SHARD_NUM', 10);
+exec sys.dbms_aqadm.set_queue_parameter('TEQ', 'STICKY_DEQUEUE', 1);
+exec sys.dbms_aqadm.set_queue_parameter('TEQ', 'KEY_BASED_ENQUEUE', 2);
+exec sys.dbms_aqadm.start_queue('TEQ');
+exec sys.DBMS_AQADM.ADD_SUBSCRIBER('TEQ', SYS.AQ$_AGENT('SUB1', NULL, 0)) ;

--- a/txeventq/kafka-connector-example/sql/setupTeq.sql
+++ b/txeventq/kafka-connector-example/sql/setupTeq.sql
@@ -1,0 +1,25 @@
+set serveroutput on
+create user if not exists &1 identified by &2
+
+alter pluggable database all close immediate;
+drop pluggable database cdb1_pdb1 including datafiles;
+drop pluggable database cdb1_pdb2 including datafiles;
+drop pluggable database cdb1_pdb3 including datafiles;
+drop pluggable database cdb1_pdb4 including datafiles;
+create pluggable database cdb1_pdb1 &1 user &1 identified by  &2 file_name_convert=('pdb0', 'pdb1');
+
+alter session set container=cdb1_pdb1;
+alter pluggable database open;
+drop tablespace users including contents and datafiles;
+CREATE TABLESPACE users DATAFILE 'users3.dbf' SIZE 500M EXTENT MANAGEMENT LOCAL SEGMENT SPACE MANAGEMENT AUTO;
+ALTER USER &1
+      DEFAULT TABLESPACE users;
+alter user &1 quota 1G on users;
+
+grant connect,resource to &1;
+grant execute on dbms_aqadm to &1;
+grant execute on dbms_aqin to &1;
+grant execute on dbms_aqjms to &1;
+grant execute on dbms_aq to &1;
+grant select_catalog_role to &1;
+


### PR DESCRIPTION
The example provides an application that can produce and consume from a Kafka topic. The application can be used in conjunction with the Oracle TxEventQ Sink/Source Connector. The application can be used to add messages to a Kafka topic and then the Oracle TxEventQ Sink connector can me used to enqueue into the specified transactional event queue. The Oracle TxEventQ Source connector can me used to dequeue messages from the specified transactional event queue into a specified Kafka topic. The Kafka consumer application can then be used to consume the messages that was sent by the Oracle TxEventQ Source connector.