### PR TITLE
Update adbs_list.tf

### DIFF
--- a/Multicloud/Azure/adbs_list.tf
+++ b/Multicloud/Azure/adbs_list.tf
@@ -1,15 +1,14 @@
-// OperationId: AutonomousDatabases_ListBySubscription
-// GET /subscriptions/{subscriptionId}/providers/Oracle.Database/autonomousDatabases
+ // List Autonomous Databases by Subscription
 data "azapi_resource_list" "listAutonomousDatabasesBySubscription" {
   type       = "Oracle.Database/autonomousDatabases@2023-09-01-preview"
-  parent_id  = data.azapi_resource.subscription.id
-  depends_on = [azapi_resource.autonomousDatabase]
+  parent_id  = "/subscriptions/${data.azapi_resource.subscription.id}" // Fixed reference to subscription ID
+  depends_on = [azapi_resource.autonomousDbDeploy] // Adjusted to the actual dependent resource
 }
 
-// OperationId: AutonomousDatabases_ListByResourceGroup
-// GET /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Oracle.Database/autonomousDatabases
+// List Autonomous Databases by Resource Group
 data "azapi_resource_list" "listAutonomousDatabasesByResourceGroup" {
   type       = "Oracle.Database/autonomousDatabases@2023-09-01-preview"
-  parent_id  = azapi_resource.resourceGroup.id
-  depends_on = [azapi_resource.autonomousDatabase]
+  parent_id  = azapi_resource.resource_group.id // Reference to the resource group ID
+  depends_on = [azapi_resource.autonomousDbDeploy] // Adjusted to the actual dependent resource
 }
+


### PR DESCRIPTION
For listAutonomousDatabasesBySubscription, the parent_id should be explicitly constructed using the subscription ID