### PR TITLE
Add examples for python-oracledb 3.0

### DIFF
--- a/python/python-oracledb/create_schema.py
+++ b/python/python-oracledb/create_schema.py
@@ -54,7 +54,7 @@ if sample_env.get_server_version() >= (21, 0):
     sample_env.run_sql_script(
         conn, "create_schema_21", main_user=sample_env.get_main_user()
     )
-if sample_env.get_server_version() >= (23, 5):
+if sample_env.get_server_version() >= (23, 7):
     sample_env.run_sql_script(
         conn, "create_schema_23", main_user=sample_env.get_main_user()
     )

--- a/python/python-oracledb/dataframe_numpy.py
+++ b/python/python-oracledb/dataframe_numpy.py
@@ -1,10 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016, 2025, Oracle and/or its affiliates.
-#
-# Portions Copyright 2007-2015, Anthony Tuininga. All rights reserved.
-#
-# Portions Copyright 2001-2007, Computronix (Canada) Ltd., Edmonton, Alberta,
-# Canada. All rights reserved.
+# Copyright (c) 2025, Oracle and/or its affiliates.
 #
 # This software is dual-licensed to you under the Universal Permissive License
 # (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
@@ -28,13 +23,14 @@
 # -----------------------------------------------------------------------------
 
 # -----------------------------------------------------------------------------
-# object_aq.py
+# dataframe_numpy.py
 #
-# Demonstrates how to use advanced queuing with objects. It makes use of a
-# simple type and queue created in the sample setup.
+# Shows how to use connection.fetch_df_all() to efficiently put data into a
+# NumPy ndarray via the DLPack standard memory layout.
 # -----------------------------------------------------------------------------
 
-import decimal
+import pyarrow
+import numpy
 
 import oracledb
 import sample_env
@@ -43,56 +39,33 @@ import sample_env
 if not sample_env.get_is_thin():
     oracledb.init_oracle_client(lib_dir=sample_env.get_oracle_client())
 
-BOOK_TYPE_NAME = "UDT_BOOK"
-QUEUE_NAME = "DEMO_BOOK_QUEUE"
-BOOK_DATA = [
-    (
-        "The Fellowship of the Ring",
-        "Tolkien, J.R.R.",
-        decimal.Decimal("10.99"),
-    ),
-    (
-        "Harry Potter and the Philosopher's Stone",
-        "Rowling, J.K.",
-        decimal.Decimal("7.99"),
-    ),
-]
-
-# connect to database
 connection = oracledb.connect(
     user=sample_env.get_main_user(),
     password=sample_env.get_main_password(),
     dsn=sample_env.get_connect_string(),
+    params=sample_env.get_connect_params(),
 )
 
-# create a queue
-books_type = connection.gettype(BOOK_TYPE_NAME)
-queue = connection.queue(QUEUE_NAME, payload_type=books_type)
-queue.deqoptions.wait = oracledb.DEQ_NO_WAIT
-queue.deqoptions.navigation = oracledb.DEQ_FIRST_MSG
+SQL = "select id from SampleQueryTab order by id"
 
-# dequeue all existing messages to ensure the queue is empty, just so that
-# the results are consistent
-while queue.deqone():
-    pass
+# Get an OracleDataFrame
+# Adjust arraysize to tune the query fetch performance
+odf = connection.fetch_df_all(statement=SQL, arraysize=100)
 
-# enqueue a few messages
-print("Enqueuing messages...")
-for title, authors, price in BOOK_DATA:
-    book = books_type.newobject()
-    book.TITLE = title
-    book.AUTHORS = authors
-    book.PRICE = price
-    print(title)
-    queue.enqone(connection.msgproperties(payload=book))
-connection.commit()
+# Convert to an ndarray via the Python DLPack specification
+pyarrow_array = pyarrow.array(odf.get_column_by_name("ID"))
+np = numpy.from_dlpack(pyarrow_array)
 
-# dequeue the messages
-print("\nDequeuing messages...")
-while True:
-    props = queue.deqone()
-    if not props:
-        break
-    print(props.payload.TITLE)
-connection.commit()
-print("\nDone.")
+# If the array has nulls, an alternative is:
+# np = pyarrow_array.to_numpy(zero_copy_only=False)
+
+print("Type:")
+print(type(np))  # <class 'numpy.ndarray'>
+
+# Perform various numpy operations on the ndarray
+
+print("\nSum:")
+print(numpy.sum(np))
+
+print("\nLog10:")
+print(numpy.log10(np))

--- a/python/python-oracledb/dataframe_pandas.py
+++ b/python/python-oracledb/dataframe_pandas.py
@@ -1,0 +1,102 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2025, Oracle and/or its affiliates.
+#
+# This software is dual-licensed to you under the Universal Permissive License
+# (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
+# 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+# either license.
+#
+# If you elect to accept the software under the Apache License, Version 2.0,
+# the following applies:
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# dataframe_pandas.py
+#
+# Shows how to use connection.fetch_df_all() and connection.fetch_df_batches()
+# to create Pandas dataframes.
+# -----------------------------------------------------------------------------
+
+import pandas
+import pyarrow
+
+import oracledb
+import sample_env
+
+# determine whether to use python-oracledb thin mode or thick mode
+if not sample_env.get_is_thin():
+    oracledb.init_oracle_client(lib_dir=sample_env.get_oracle_client())
+
+connection = oracledb.connect(
+    user=sample_env.get_main_user(),
+    password=sample_env.get_main_password(),
+    dsn=sample_env.get_connect_string(),
+    params=sample_env.get_connect_params(),
+)
+
+SQL = "select id, name from SampleQueryTab order by id"
+
+# -----------------------------------------------------------------------------
+#
+# Fetching all records
+
+# Get an OracleDataFrame.
+# Adjust arraysize to tune the query fetch performance
+odf = connection.fetch_df_all(statement=SQL, arraysize=100)
+
+# Get a Pandas DataFrame from the data
+df = pyarrow.Table.from_arrays(
+    odf.column_arrays(), names=odf.column_names()
+).to_pandas()
+
+# Perform various Pandas operations on the DataFrame
+
+print("Columns:")
+print(df.columns)
+
+print("\nDataframe description:")
+print(df.describe())
+
+print("\nLast three rows:")
+print(df.tail(3))
+
+print("\nTransform:")
+print(df.T)
+
+# -----------------------------------------------------------------------------
+#
+# Batch record fetching
+#
+# Note that since this particular example ends up with all query rows being
+# held in memory, it would be more efficient to use fetch_df_all() as shown
+# above.
+
+print("\nFetching in batches:")
+df = pandas.DataFrame()
+
+# Tune 'size' for your data set. Here it is small to show the batch fetch
+# behavior on the sample table.
+for odf in connection.fetch_df_batches(statement=SQL, size=10):
+    df_b = pyarrow.Table.from_arrays(
+        odf.column_arrays(), names=odf.column_names()
+    ).to_pandas()
+    print(f"Appending {df_b.shape[0]} rows")
+    df = pandas.concat([df, df_b], ignore_index=True)
+
+r, c = df.shape
+print(f"{r} rows, {c} columns")
+
+print("\nLast three rows:")
+print(df.tail(3))

--- a/python/python-oracledb/dataframe_pandas_async.py
+++ b/python/python-oracledb/dataframe_pandas_async.py
@@ -1,0 +1,109 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2025, Oracle and/or its affiliates.
+#
+# This software is dual-licensed to you under the Universal Permissive License
+# (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
+# 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+# either license.
+#
+# If you elect to accept the software under the Apache License, Version 2.0,
+# the following applies:
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# dataframe_pandas_async.py
+#
+# An asynchronous version of dataframe_pandas.py
+#
+# Shows how to use AsyncConnection.fetch_df_all() and
+# AsyncConnection.fetch_df_batches(). This example then creates Pandas
+# dataframes. Alternative dataframe libraries could be used similar to the
+# other, synchronous, data frame samples.
+# -----------------------------------------------------------------------------
+
+import asyncio
+
+import pandas
+import pyarrow
+
+import oracledb
+import sample_env
+
+
+async def main():
+    connection = await oracledb.connect_async(
+        user=sample_env.get_main_user(),
+        password=sample_env.get_main_password(),
+        dsn=sample_env.get_connect_string(),
+        params=sample_env.get_connect_params(),
+    )
+
+    SQL = "select id, name from SampleQueryTab order by id"
+
+    # -------------------------------------------------------------------------
+    #
+    # Fetching all records
+
+    # Get an OracleDataFrame.
+    # Adjust arraysize to tune the query fetch performance
+    odf = await connection.fetch_df_all(statement=SQL, arraysize=100)
+
+    # Get a Pandas DataFrame from the data
+    df = pyarrow.Table.from_arrays(
+        odf.column_arrays(), names=odf.column_names()
+    ).to_pandas()
+
+    # Perform various Pandas operations on the DataFrame
+
+    print("Columns:")
+    print(df.columns)
+
+    print("\nDataframe description:")
+    print(df.describe())
+
+    print("\nLast three rows:")
+    print(df.tail(3))
+
+    print("\nTransform:")
+    print(df.T)
+
+    # -------------------------------------------------------------------------
+    #
+    # Batch record fetching
+    #
+    # Note that since this particular example ends up with all query rows being
+    # held in memory, it would be more efficient to use fetch_df_all() as shown
+    # above.
+
+    print("\nFetching in batches:")
+    df = pandas.DataFrame()
+
+    # Tune 'size' for your data set. Here it is small to show the batch fetch
+    # behavior on the sample table.
+    async for odf in connection.fetch_df_batches(statement=SQL, size=10):
+        df_b = pyarrow.Table.from_arrays(
+            odf.column_arrays(), names=odf.column_names()
+        ).to_pandas()
+        print(f"Appending {df_b.shape[0]} rows")
+        df = pandas.concat([df, df_b], ignore_index=True)
+
+    r, c = df.shape
+    print(f"{r} rows, {c} columns")
+
+    print("\nLast three rows:")
+    print(df.tail(3))
+
+
+asyncio.run(main())

--- a/python/python-oracledb/dataframe_polars.py
+++ b/python/python-oracledb/dataframe_polars.py
@@ -1,10 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016, 2025, Oracle and/or its affiliates.
-#
-# Portions Copyright 2007-2015, Anthony Tuininga. All rights reserved.
-#
-# Portions Copyright 2001-2007, Computronix (Canada) Ltd., Edmonton, Alberta,
-# Canada. All rights reserved.
+# Copyright (c) 2025, Oracle and/or its affiliates.
 #
 # This software is dual-licensed to you under the Universal Permissive License
 # (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
@@ -28,13 +23,14 @@
 # -----------------------------------------------------------------------------
 
 # -----------------------------------------------------------------------------
-# object_aq.py
+# dataframe_polars.py
 #
-# Demonstrates how to use advanced queuing with objects. It makes use of a
-# simple type and queue created in the sample setup.
+# Shows how to use connection.fetch_df_all() to efficiently put data into
+# Polars DataFrames and Series.
 # -----------------------------------------------------------------------------
 
-import decimal
+import pyarrow
+import polars
 
 import oracledb
 import sample_env
@@ -43,56 +39,58 @@ import sample_env
 if not sample_env.get_is_thin():
     oracledb.init_oracle_client(lib_dir=sample_env.get_oracle_client())
 
-BOOK_TYPE_NAME = "UDT_BOOK"
-QUEUE_NAME = "DEMO_BOOK_QUEUE"
-BOOK_DATA = [
-    (
-        "The Fellowship of the Ring",
-        "Tolkien, J.R.R.",
-        decimal.Decimal("10.99"),
-    ),
-    (
-        "Harry Potter and the Philosopher's Stone",
-        "Rowling, J.K.",
-        decimal.Decimal("7.99"),
-    ),
-]
-
-# connect to database
 connection = oracledb.connect(
     user=sample_env.get_main_user(),
     password=sample_env.get_main_password(),
     dsn=sample_env.get_connect_string(),
+    params=sample_env.get_connect_params(),
 )
 
-# create a queue
-books_type = connection.gettype(BOOK_TYPE_NAME)
-queue = connection.queue(QUEUE_NAME, payload_type=books_type)
-queue.deqoptions.wait = oracledb.DEQ_NO_WAIT
-queue.deqoptions.navigation = oracledb.DEQ_FIRST_MSG
+# -----------------------------------------------------------------------------
+#
+# Polars DataFrame
 
-# dequeue all existing messages to ensure the queue is empty, just so that
-# the results are consistent
-while queue.deqone():
-    pass
+SQL1 = "select * from SampleQueryTab order by id"
 
-# enqueue a few messages
-print("Enqueuing messages...")
-for title, authors, price in BOOK_DATA:
-    book = books_type.newobject()
-    book.TITLE = title
-    book.AUTHORS = authors
-    book.PRICE = price
-    print(title)
-    queue.enqone(connection.msgproperties(payload=book))
-connection.commit()
+# Get an OracleDataFrame
+# Adjust arraysize to tune the query fetch performance
+odf = connection.fetch_df_all(statement=SQL1, arraysize=100)
 
-# dequeue the messages
-print("\nDequeuing messages...")
-while True:
-    props = queue.deqone()
-    if not props:
-        break
-    print(props.payload.TITLE)
-connection.commit()
-print("\nDone.")
+# Convert to a Polars DataFrame
+pyarrow_table = pyarrow.Table.from_arrays(
+    odf.column_arrays(), names=odf.column_names()
+)
+p = polars.from_arrow(pyarrow_table)
+
+print(type(p))  # <class 'polars.dataframe.frame.DataFrame'>
+
+r, c = p.shape
+print(f"{r} rows, {c} columns")
+
+print("\nSum:")
+print(p.sum())
+
+# -----------------------------------------------------------------------------
+#
+# Polars Series
+
+SQL2 = "select id from SampleQueryTab order by id"
+
+# Get an OracleDataFrame
+# Adjust arraysize to tune the query fetch performance
+odf = connection.fetch_df_all(statement=SQL2, arraysize=100)
+
+# Convert to a Polars Series
+pyarrow_array = pyarrow.array(odf.get_column_by_name("ID"))
+p = polars.from_arrow(pyarrow_array)
+
+print(type(p))  # <class 'polars.series.series.Series'>
+
+(r,) = p.shape
+print(f"{r} rows")
+
+print("\nSum:")
+print(p.sum())
+
+print("\nLog10:")
+print(p.log10())

--- a/python/python-oracledb/dataframe_torch.py
+++ b/python/python-oracledb/dataframe_torch.py
@@ -1,10 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright (c) 2016, 2025, Oracle and/or its affiliates.
-#
-# Portions Copyright 2007-2015, Anthony Tuininga. All rights reserved.
-#
-# Portions Copyright 2001-2007, Computronix (Canada) Ltd., Edmonton, Alberta,
-# Canada. All rights reserved.
+# Copyright (c) 2025, Oracle and/or its affiliates.
 #
 # This software is dual-licensed to you under the Universal Permissive License
 # (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
@@ -28,13 +23,14 @@
 # -----------------------------------------------------------------------------
 
 # -----------------------------------------------------------------------------
-# object_aq.py
+# dataframe_torch.py
 #
-# Demonstrates how to use advanced queuing with objects. It makes use of a
-# simple type and queue created in the sample setup.
+# Shows how to use connection.fetch_df_all() to efficiently put data into a
+# Torch tensor via the DLPack standard memory layout.
 # -----------------------------------------------------------------------------
 
-import decimal
+import pyarrow
+import torch
 
 import oracledb
 import sample_env
@@ -43,56 +39,29 @@ import sample_env
 if not sample_env.get_is_thin():
     oracledb.init_oracle_client(lib_dir=sample_env.get_oracle_client())
 
-BOOK_TYPE_NAME = "UDT_BOOK"
-QUEUE_NAME = "DEMO_BOOK_QUEUE"
-BOOK_DATA = [
-    (
-        "The Fellowship of the Ring",
-        "Tolkien, J.R.R.",
-        decimal.Decimal("10.99"),
-    ),
-    (
-        "Harry Potter and the Philosopher's Stone",
-        "Rowling, J.K.",
-        decimal.Decimal("7.99"),
-    ),
-]
-
-# connect to database
 connection = oracledb.connect(
     user=sample_env.get_main_user(),
     password=sample_env.get_main_password(),
     dsn=sample_env.get_connect_string(),
+    params=sample_env.get_connect_params(),
 )
 
-# create a queue
-books_type = connection.gettype(BOOK_TYPE_NAME)
-queue = connection.queue(QUEUE_NAME, payload_type=books_type)
-queue.deqoptions.wait = oracledb.DEQ_NO_WAIT
-queue.deqoptions.navigation = oracledb.DEQ_FIRST_MSG
+SQL = "select id from SampleQueryTab order by id"
 
-# dequeue all existing messages to ensure the queue is empty, just so that
-# the results are consistent
-while queue.deqone():
-    pass
+# Get an OracleDataFrame
+# Adjust arraysize to tune the query fetch performance
+odf = connection.fetch_df_all(statement=SQL, arraysize=100)
 
-# enqueue a few messages
-print("Enqueuing messages...")
-for title, authors, price in BOOK_DATA:
-    book = books_type.newobject()
-    book.TITLE = title
-    book.AUTHORS = authors
-    book.PRICE = price
-    print(title)
-    queue.enqone(connection.msgproperties(payload=book))
-connection.commit()
+# Convert to a Torch tensor via the Python DLPack specification
+pyarrow_array = pyarrow.array(odf.get_column_by_name("ID"))
+tt = torch.from_dlpack(pyarrow_array)
 
-# dequeue the messages
-print("\nDequeuing messages...")
-while True:
-    props = queue.deqone()
-    if not props:
-        break
-    print(props.payload.TITLE)
-connection.commit()
-print("\nDone.")
+print(type(tt))  # <class 'torch.Tensor'>
+
+# Perform various Torch operations on the tensor
+
+print("\nSum:")
+print(torch.sum(tt))
+
+print("\nLog10:")
+print(torch.log10(tt))

--- a/python/python-oracledb/multi_consumer_aq.py
+++ b/python/python-oracledb/multi_consumer_aq.py
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright (c) 2020, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2025, Oracle and/or its affiliates.
 #
 # Portions Copyright 2007-2015, Anthony Tuininga. All rights reserved.
 #
@@ -37,8 +37,9 @@
 import oracledb
 import sample_env
 
-# this script is currently only supported in python-oracledb thick mode
-oracledb.init_oracle_client(lib_dir=sample_env.get_oracle_client())
+# determine whether to use python-oracledb thin mode or thick mode
+if not sample_env.get_is_thin():
+    oracledb.init_oracle_client(lib_dir=sample_env.get_oracle_client())
 
 QUEUE_NAME = "DEMO_RAW_QUEUE_MULTI"
 PAYLOAD_DATA = [
@@ -61,35 +62,32 @@ queue.deqoptions.wait = oracledb.DEQ_NO_WAIT
 queue.deqoptions.navigation = oracledb.DEQ_FIRST_MSG
 
 # enqueue a few messages
-with connection.cursor() as cursor:
-    print("Enqueuing messages...")
-    for data in PAYLOAD_DATA:
-        print(data)
-        queue.enqone(connection.msgproperties(payload=data))
-    connection.commit()
-    print()
+print("Enqueuing messages...")
+for data in PAYLOAD_DATA:
+    print(data)
+    queue.enqone(connection.msgproperties(payload=data))
+connection.commit()
+print()
 
 # dequeue the messages for consumer A
-with connection.cursor() as cursor:
-    print("Dequeuing the messages for consumer A...")
-    queue.deqoptions.consumername = "SUBSCRIBER_A"
-    while True:
-        props = queue.deqone()
-        if not props:
-            break
-        print(props.payload.decode())
-    connection.commit()
-    print()
+print("Dequeuing the messages for consumer A...")
+queue.deqoptions.consumername = "SUBSCRIBER_A"
+while True:
+    props = queue.deqone()
+    if not props:
+        break
+    print(props.payload.decode())
+connection.commit()
+print()
 
 # dequeue the message for consumer B
-with connection.cursor() as cursor:
-    print("Dequeuing the messages for consumer B...")
-    queue.deqoptions.consumername = "SUBSCRIBER_B"
-    while True:
-        props = queue.deqone()
-        if not props:
-            break
-        print(props.payload.decode())
-    connection.commit()
+print("Dequeuing the messages for consumer B...")
+queue.deqoptions.consumername = "SUBSCRIBER_B"
+while True:
+    props = queue.deqone()
+    if not props:
+        break
+    print(props.payload.decode())
+connection.commit()
 
 print("\nDone.")

--- a/python/python-oracledb/pipelining_error.py
+++ b/python/python-oracledb/pipelining_error.py
@@ -76,7 +76,7 @@ async def main():
     results = await connection.run_pipeline(pipeline, continue_on_error=True)
 
     for i, result in enumerate(results):
-        statement = pipeline.operations[i].statement
+        statement = result.operation.statement
         if result.warning:
             print(
                 f"Warning {result.warning.full_code} " f"in operation {i+1}:\n"

--- a/python/python-oracledb/plsql_batch.py
+++ b/python/python-oracledb/plsql_batch.py
@@ -1,0 +1,193 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2024, Oracle and/or its affiliates.
+#
+# This software is dual-licensed to you under the Universal Permissive License
+# (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
+# 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+# either license.
+#
+# If you elect to accept the software under the Apache License, Version 2.0,
+# the following applies:
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# plsql_batch.py
+#
+# Demonstrates using executemany() to make repeated calls to a PL/SQL procedure
+#
+# Note in python-oracledb Thick mode, when cursor.executemany() is used for
+# PL/SQL code that returns OUT binds, it will have the same performance
+# characteristics as repeated calls to cursor.execute().
+# -----------------------------------------------------------------------------
+
+import oracledb
+import sample_env
+
+# determine whether to use python-oracledb thin mode or thick mode
+if not sample_env.get_is_thin():
+    oracledb.init_oracle_client(lib_dir=sample_env.get_oracle_client())
+
+connection = oracledb.connect(
+    user=sample_env.get_main_user(),
+    password=sample_env.get_main_password(),
+    dsn=sample_env.get_connect_string(),
+    params=sample_env.get_connect_params(),
+)
+
+# -----------------------------------------------------------------------------
+# IN and OUT PL/SQL parameter examples
+# Also shows passing in an object
+# -----------------------------------------------------------------------------
+
+# Setup
+
+with connection.cursor() as cursor:
+    stmts = [
+        """create or replace type my_varchar_list as table of varchar2(100)""",
+        """create or replace procedure myproc
+                  (p in number, names in my_varchar_list, count out number) as
+           begin
+               count := p + names.count;
+           end;""",
+    ]
+    for s in stmts:
+        cursor.execute(s)
+        if cursor.warning:
+            print(cursor.warning)
+            print(s)
+
+type_obj = connection.gettype("MY_VARCHAR_LIST")
+
+# Example 1: positional binds
+
+with connection.cursor() as cursor:
+
+    obj1 = type_obj.newobject()
+    obj1.extend(["Alex", "Bobbie"])
+    obj2 = type_obj.newobject()
+    obj2.extend(["Charlie", "Dave", "Eric"])
+    obj3 = type_obj.newobject()
+    obj3.extend(["Fred", "Georgia", "Helen", "Ian"])
+
+    data = [
+        (1, obj1),
+        (2, obj2),
+        (3, obj3),
+    ]
+
+    count = cursor.var(oracledb.DB_TYPE_NUMBER, arraysize=len(data))
+    cursor.setinputsizes(None, type_obj, count)
+
+    cursor.executemany("begin myproc(:1, :2, :3); end;", data)
+    print(count.values)  # [3, 5, 7]
+
+# Example 2: named binds
+
+with connection.cursor() as cursor:
+
+    obj1 = type_obj.newobject()
+    obj1.extend(["Alex", "Bobbie"])
+    obj2 = type_obj.newobject()
+    obj2.extend(["Charlie", "Dave", "Eric"])
+    obj3 = type_obj.newobject()
+    obj3.extend(["Fred", "Georgia", "Helen", "Ian"])
+
+    data = [
+        {"p": 100, "names": obj1},
+        {"p": 200, "names": obj2},
+        {"p": 300, "names": obj3},
+    ]
+
+    count = cursor.var(oracledb.DB_TYPE_NUMBER, arraysize=len(data))
+    cursor.setinputsizes(p=None, names=type_obj, count=count)
+
+    cursor.executemany("begin myproc(:p, :names, :count); end;", data)
+    print(count.values)  # [102, 203, 304]
+
+# -----------------------------------------------------------------------------
+# IN/OUT PL/SQL parameter examples
+# -----------------------------------------------------------------------------
+
+# Setup
+
+with connection.cursor() as cursor:
+    stmt = """create or replace procedure myproc2
+                     (p1 in number, p2 in out varchar2) as
+              begin
+                  p2 := p2 || ' ' || p1;
+              end;"""
+    cursor.execute(stmt)
+    if cursor.warning:
+        print(cursor.warning)
+        print(stmt)
+
+# Example 3: positional binds
+
+with connection.cursor() as cursor:
+    data = [(440, "Gregory"), (550, "Haley"), (660, "Ian")]
+    outvals = cursor.var(
+        oracledb.DB_TYPE_VARCHAR, size=100, arraysize=len(data)
+    )
+    cursor.setinputsizes(None, outvals)
+
+    cursor.executemany("begin myproc2(:1, :2); end;", data)
+    print(outvals.values)  # ['Gregory 440', 'Haley 550', 'Ian 660']
+
+# Example 4: positional binds, utilizing setvalue()
+
+with connection.cursor() as cursor:
+    data = [(777,), (888,), (999,)]
+
+    inoutvals = cursor.var(
+        oracledb.DB_TYPE_VARCHAR, size=100, arraysize=len(data)
+    )
+    inoutvals.setvalue(0, "Roger")
+    inoutvals.setvalue(1, "Sally")
+    inoutvals.setvalue(2, "Tom")
+    cursor.setinputsizes(None, inoutvals)
+
+    cursor.executemany("begin myproc2(:1, :2); end;", data)
+    print(inoutvals.values)  # ['Roger 777', 'Sally 888', 'Tom 999']
+
+# Example 5: named binds
+
+with connection.cursor() as cursor:
+    data = [
+        {"p1bv": 100, "p2bv": "Alfie"},
+        {"p1bv": 200, "p2bv": "Brian"},
+        {"p1bv": 300, "p2bv": "Cooper"},
+    ]
+    outvals = cursor.var(
+        oracledb.DB_TYPE_VARCHAR, size=100, arraysize=len(data)
+    )
+    cursor.setinputsizes(p1bv=None, p2bv=outvals)
+
+    cursor.executemany("begin myproc2(:p1bv, :p2bv); end;", data)
+    print(outvals.values)  # ['Alfie 100', 'Brian 200', 'Cooper 300']
+
+# Example 6: named binds, utilizing setvalue()
+
+with connection.cursor() as cursor:
+    inoutvals = cursor.var(
+        oracledb.DB_TYPE_VARCHAR, size=100, arraysize=len(data)
+    )
+    inoutvals.setvalue(0, "Dean")
+    inoutvals.setvalue(1, "Elsa")
+    inoutvals.setvalue(2, "Felix")
+    data = [{"p1bv": 101}, {"p1bv": 202}, {"p1bv": 303}]
+    cursor.setinputsizes(p1bv=None, p2bv=inoutvals)
+
+    cursor.executemany("begin myproc2(:p1bv, :p2bv); end;", data)
+    print(inoutvals.values)  # ['Dean 101', 'Elsa 202', 'Felix 303']

--- a/python/python-oracledb/plsql_batch_async.py
+++ b/python/python-oracledb/plsql_batch_async.py
@@ -1,0 +1,201 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2024, Oracle and/or its affiliates.
+#
+# This software is dual-licensed to you under the Universal Permissive License
+# (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
+# 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+# either license.
+#
+# If you elect to accept the software under the Apache License, Version 2.0,
+# the following applies:
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# plsql_batch_async.py
+#
+# An asynchronous version of plsql_batch.py
+#
+# Demonstrates using executemany() to make repeated calls to a PL/SQL procedure
+# -----------------------------------------------------------------------------
+
+import asyncio
+
+import oracledb
+import sample_env
+
+
+async def main():
+
+    connection = await oracledb.connect_async(
+        user=sample_env.get_main_user(),
+        password=sample_env.get_main_password(),
+        dsn=sample_env.get_connect_string(),
+        params=sample_env.get_connect_params(),
+    )
+
+    # -------------------------------------------------------------------------
+    # IN and OUT PL/SQL parameter examples
+    # Also shows passing in an object
+    # -------------------------------------------------------------------------
+
+    # Setup
+
+    pipeline = oracledb.create_pipeline()
+
+    pipeline.add_execute(
+        """create or replace type my_varchar_list
+               as table of varchar2(100)"""
+    )
+
+    pipeline.add_execute(
+        """create or replace procedure myproc
+               (p in number, names in my_varchar_list, count out number) as
+           begin
+               count := p + names.count;
+           end;"""
+    )
+
+    await connection.run_pipeline(pipeline)
+
+    # Example 1: positional binds
+
+    type_obj = await connection.gettype("MY_VARCHAR_LIST")
+
+    with connection.cursor() as cursor:
+
+        obj1 = type_obj.newobject()
+        obj1.extend(["Alex", "Bobbie"])
+        obj2 = type_obj.newobject()
+        obj2.extend(["Charlie", "Dave", "Eric"])
+        obj3 = type_obj.newobject()
+        obj3.extend(["Fred", "Georgia", "Helen", "Ian"])
+
+        data = [
+            (1, obj1),
+            (2, obj2),
+            (3, obj3),
+        ]
+
+        count = cursor.var(oracledb.DB_TYPE_NUMBER, arraysize=len(data))
+        cursor.setinputsizes(None, type_obj, count)
+
+        await cursor.executemany("begin myproc(:1, :2, :3); end;", data)
+        print(count.values)  # [3, 5, 7]
+
+    # Example 2: named binds
+
+    with connection.cursor() as cursor:
+
+        obj1 = type_obj.newobject()
+        obj1.extend(["Alex", "Bobbie"])
+        obj2 = type_obj.newobject()
+        obj2.extend(["Charlie", "Dave", "Eric"])
+        obj3 = type_obj.newobject()
+        obj3.extend(["Fred", "Georgia", "Helen", "Ian"])
+
+        data = [
+            {"p": 100, "names": obj1},
+            {"p": 200, "names": obj2},
+            {"p": 300, "names": obj3},
+        ]
+
+        count = cursor.var(oracledb.DB_TYPE_NUMBER, arraysize=len(data))
+        cursor.setinputsizes(p=None, names=type_obj, count=count)
+
+        await cursor.executemany(
+            "begin myproc(:p, :names, :count); end;", data
+        )
+
+        print(count.values)  # [102, 203, 304]
+
+    # -------------------------------------------------------------------------
+    # IN/OUT PL/SQL parameter examples
+    # -------------------------------------------------------------------------
+
+    # Setup
+
+    pipeline = oracledb.create_pipeline()
+
+    pipeline.add_execute(
+        """create or replace procedure myproc2
+              (p1 in number, p2 in out varchar2) as
+           begin
+               p2 := p2 || ' ' || p1;
+           end;"""
+    )
+
+    await connection.run_pipeline(pipeline)
+
+    # Example 3: positional binds
+
+    with connection.cursor() as cursor:
+        data = [(440, "Gregory"), (550, "Haley"), (660, "Ian")]
+        outvals = cursor.var(
+            oracledb.DB_TYPE_VARCHAR, size=100, arraysize=len(data)
+        )
+        cursor.setinputsizes(None, outvals)
+
+        await cursor.executemany("begin myproc2(:1, :2); end;", data)
+        print(outvals.values)  # ['Gregory 440', 'Haley 550', 'Ian 660']
+
+    # Example 4: positional binds, utilizing setvalue()
+
+    with connection.cursor() as cursor:
+        data = [(777,), (888,), (999,)]
+
+        inoutvals = cursor.var(
+            oracledb.DB_TYPE_VARCHAR, size=100, arraysize=len(data)
+        )
+        inoutvals.setvalue(0, "Roger")
+        inoutvals.setvalue(1, "Sally")
+        inoutvals.setvalue(2, "Tom")
+        cursor.setinputsizes(None, inoutvals)
+
+        await cursor.executemany("begin myproc2(:1, :2); end;", data)
+        print(inoutvals.values)  # ['Roger 777', 'Sally 888', 'Tom 999']
+
+    # Example 5: named binds
+
+    with connection.cursor() as cursor:
+        data = [
+            {"p1bv": 100, "p2bv": "Alfie"},
+            {"p1bv": 200, "p2bv": "Brian"},
+            {"p1bv": 300, "p2bv": "Cooper"},
+        ]
+        outvals = cursor.var(
+            oracledb.DB_TYPE_VARCHAR, size=100, arraysize=len(data)
+        )
+        cursor.setinputsizes(p1bv=None, p2bv=outvals)
+
+        await cursor.executemany("begin myproc2(:p1bv, :p2bv); end;", data)
+        print(outvals.values)  # ['Alfie 100', 'Brian 200', 'Cooper 300']
+
+    # Example 6: named binds, utilizing setvalue()
+
+    with connection.cursor() as cursor:
+        inoutvals = cursor.var(
+            oracledb.DB_TYPE_VARCHAR, size=100, arraysize=len(data)
+        )
+        inoutvals.setvalue(0, "Dean")
+        inoutvals.setvalue(1, "Elsa")
+        inoutvals.setvalue(2, "Felix")
+        data = [{"p1bv": 101}, {"p1bv": 202}, {"p1bv": 303}]
+        cursor.setinputsizes(p1bv=None, p2bv=inoutvals)
+
+        await cursor.executemany("begin myproc2(:p1bv, :p2bv); end;", data)
+        print(inoutvals.values)  # ['Dean 101', 'Elsa 202', 'Felix 303']
+
+
+asyncio.run(main())

--- a/python/python-oracledb/sql/create_schema.sql
+++ b/python/python-oracledb/sql/create_schema.sql
@@ -391,6 +391,44 @@ insert into &main_user..SampleQueryTab values (6, 'Frankie')
 /
 insert into &main_user..SampleQueryTab values (7, 'Gerri')
 /
+insert into &main_user..SampleQueryTab values (8, 'Harriet')
+/
+insert into &main_user..SampleQueryTab values (9, 'Isabelle')
+/
+insert into &main_user..SampleQueryTab values (10, 'Jarek')
+/
+insert into &main_user..SampleQueryTab values (11, 'Krishna')
+/
+insert into &main_user..SampleQueryTab values (12, 'Leo')
+/
+insert into &main_user..SampleQueryTab values (13, 'Mia')
+/
+insert into &main_user..SampleQueryTab values (14, 'Nathalie')
+/
+insert into &main_user..SampleQueryTab values (15, 'Oscar')
+/
+insert into &main_user..SampleQueryTab values (16, 'Pia')
+/
+insert into &main_user..SampleQueryTab values (17, 'Quentin')
+/
+insert into &main_user..SampleQueryTab values (18, 'Roger')
+/
+insert into &main_user..SampleQueryTab values (19, 'Sally')
+/
+insert into &main_user..SampleQueryTab values (20, 'Tully')
+/
+insert into &main_user..SampleQueryTab values (21, 'Una')
+/
+insert into &main_user..SampleQueryTab values (22, 'Valerie')
+/
+insert into &main_user..SampleQueryTab values (23, 'William')
+/
+insert into &main_user..SampleQueryTab values (24, 'Xavier')
+/
+insert into &main_user..SampleQueryTab values (25, 'Yasmin')
+/
+insert into &main_user..SampleQueryTab values (26, 'Zach')
+/
 
 commit
 /

--- a/python/python-oracledb/sql/create_schema_23.sql
+++ b/python/python-oracledb/sql/create_schema_23.sql
@@ -27,15 +27,16 @@
  *
  * Performs the actual work of creating and populating the schemas with the
  * database objects used by the python-oracledb samples that require Oracle
- * Database 23.5 or higher. It is executed by the Python script
+ * Database 23.7 or higher. It is executed by the Python script
  * create_schema.py.
  *---------------------------------------------------------------------------*/
 
 create table &main_user..SampleVectorTab (
-    v32  vector(3, float32),
-    v64  vector(3, float64),
-    v8   vector(3, int8),
-    vbin vector(24, binary)
+    v32       vector(3, float32),
+    v64       vector(3, float64),
+    v8        vector(3, int8),
+    vbin      vector(24, binary),
+    v64sparse vector(30, float64, sparse)
 )
 /
 

--- a/python/python-oracledb/vector_async.py
+++ b/python/python-oracledb/vector_async.py
@@ -46,9 +46,14 @@ async def main():
         params=sample_env.get_connect_params(),
     )
 
-    # this script only works with Oracle Database 23.5 or later
-    if sample_env.get_server_version() < (23, 5):
-        sys.exit("This example requires Oracle Database 23.5 or later.")
+    # this script only works with Oracle Database 23.7 or later
+    #
+    # The VECTOR datatype was initially introduced in Oracle Database 23.4.
+    # The BINARY vector format was introduced in Oracle Database 23.5.
+    # The SPARSE vector format was introduced in Oracle Database 23.7.
+
+    if sample_env.get_server_version() < (23, 7):
+        sys.exit("This example requires Oracle Database 23.7 or later.")
 
     with connection.cursor() as cursor:
         # Single-row insert
@@ -56,15 +61,19 @@ async def main():
         vector1_data_64 = array.array("d", [11.25, 11.75, 11.5])
         vector1_data_8 = array.array("b", [1, 2, 3])
         vector1_data_bin = array.array("B", [180, 150, 100])
+        vector1_data_sparse64 = oracledb.SparseVector(
+            30, [9, 16, 24], array.array("d", [19.125, 78.5, 977.375])
+        )
 
         await cursor.execute(
-            """insert into SampleVectorTab (v32, v64, v8, vbin)
-               values (:1, :2, :3, :4)""",
+            """insert into SampleVectorTab (v32, v64, v8, vbin, v64sparse)
+               values (:1, :2, :3, :4, :5)""",
             [
                 vector1_data_32,
                 vector1_data_64,
                 vector1_data_8,
                 vector1_data_bin,
+                vector1_data_sparse64,
             ],
         )
 
@@ -73,11 +82,17 @@ async def main():
         vector2_data_64 = array.array("d", [22.25, 22.75, 22.5])
         vector2_data_8 = array.array("b", [4, 5, 6])
         vector2_data_bin = array.array("B", [40, 15, 255])
+        vector2_data_sparse64 = oracledb.SparseVector(
+            30, [3, 10, 12], array.array("d", [2.5, 2.5, 1.0])
+        )
 
         vector3_data_32 = array.array("f", [3.625, 3.5, 3.0])
         vector3_data_64 = array.array("d", [33.25, 33.75, 33.5])
         vector3_data_8 = array.array("b", [7, 8, 9])
         vector3_data_bin = array.array("B", [0, 17, 101])
+        vector3_data_sparse64 = oracledb.SparseVector(
+            30, [8, 15, 29], array.array("d", [1.125, 200.5, 100.0])
+        )
 
         rows = [
             (
@@ -85,25 +100,28 @@ async def main():
                 vector2_data_64,
                 vector2_data_8,
                 vector2_data_bin,
+                vector2_data_sparse64,
             ),
             (
                 vector3_data_32,
                 vector3_data_64,
                 vector3_data_8,
                 vector3_data_bin,
+                vector3_data_sparse64,
             ),
         ]
 
         await cursor.executemany(
-            """insert into SampleVectorTab (v32, v64, v8, vbin)
-               values (:1, :2, :3, :4)""",
+            """insert into SampleVectorTab (v32, v64, v8, vbin, v64sparse)
+               values (:1, :2, :3, :4, :5)""",
             rows,
         )
 
         # Query
         await cursor.execute("select * from SampleVectorTab")
 
-        # Each vector is represented as an array.array type
+        # Each non-sparse vector is represented as an array.array type.
+        # Sparse vectors are represented as oracledb.SparseVector() instances
         async for row in cursor:
             print(row)
 


### PR DESCRIPTION
Update examples for python-oracledb 3.0, in particular added the new dataframe query examples.