### PR TITLE
AQ-JMS Example with Transactional semantic

### DIFF
--- a/java/jdbcdriver-virtual-threads/.gitignore
+++ b/java/jdbcdriver-virtual-threads/.gitignore
@@ -1,2 +1,3 @@
 # A config file which may contain a username and password
 **/config.properties
+/target/

--- a/txeventq/jms-example/pom.xml
+++ b/txeventq/jms-example/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"   
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0   
+http://maven.apache.org/xsd/maven-4.0.0.xsd">  
+ 
+  <modelVersion>4.0.0</modelVersion>  
+ 
+  <groupId>com.oracle.jms.example</groupId>  
+  <artifactId>AQ-JMS-Examples</artifactId>  
+  <version>1.0</version>  
+  <packaging>jar</packaging>  
+ 
+  <name>AQ JMS Examples</name>  
+  <url>http://maven.apache.org</url>  
+ 
+  <dependencies>  
+	<!-- https://mvnrepository.com/artifact/com.oracle.database.messaging/aqapi-jakarta -->
+	<dependency>
+    	<groupId>com.oracle.database.messaging</groupId>
+    	<artifactId>aqapi-jakarta</artifactId>
+   	 	<version>23.3.1.0</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc11 -->
+	<dependency>
+    	<groupId>com.oracle.database.jdbc</groupId>
+    	<artifactId>ojdbc11</artifactId>
+    	<version>23.3.0.23.09</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/jakarta.transaction/jakarta.transaction-api -->
+	<dependency>
+    	<groupId>jakarta.transaction</groupId>
+    	<artifactId>jakarta.transaction-api</artifactId>
+    	<version>2.0.1</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/jakarta.jms/jakarta.jms-api -->
+	<dependency>
+    	<groupId>jakarta.jms</groupId>
+    	<artifactId>jakarta.jms-api</artifactId>
+    	<version>3.1.0</version>
+	</dependency>   
+  </dependencies>    
+</project>

--- a/txeventq/jms-example/sql/stupTxEQ.sql
+++ b/txeventq/jms-example/sql/stupTxEQ.sql
@@ -1,0 +1,26 @@
+-- Create database user
+create user aqjmsuser identified by Welcome_123#;
+grant connect, resource to aqjmsuser;
+grant execute on dbms_aq to aqjmsuser;
+grant execute on dbms_aqadm to aqjmsuser;
+grant execute on dbms_aqin to aqjmsuser;
+grant unlimited tablespace to aqjmsuser;
+
+-- Create Transactional Event Queue TOPIC_IN and TOPIC_OUT. Add a consumer Consumer1 for both
+Declare
+  subscriber sys.aq$_agent;
+Begin
+   subscriber := sys.aq$_agent('Consumer1', NULL, NULL);
+   dbms_aqadm.create_transactional_event_queue(queue_name=>'aqjmsuser.TOPIC_IN', multiple_consumers=>TRUE);
+   dbms_aqadm.start_queue('aqjmsuser.TOPIC_IN');
+End;
+/
+
+Declare
+  subscriber sys.aq$_agent;
+Begin
+   subscriber := sys.aq$_agent('Consumer1', NULL, NULL);
+   dbms_aqadm.create_transactional_event_queue(queue_name=>'aqjmsuser.TOPIC_OUT', multiple_consumers=>TRUE);
+   dbms_aqadm.start_queue('aqjmsuser.TOPIC_OUT');
+End;
+/

--- a/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsExactlyOnceConsumeProcessProduce.java
+++ b/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsExactlyOnceConsumeProcessProduce.java
@@ -1,0 +1,51 @@
+package com.oracle.jms.example.transactional;
+
+public class JmsExactlyOnceConsumeProcessProduce {
+	public static void main(String[] args) {
+		try {
+			oracle.jdbc.pool.OracleDataSource ods = new oracle.jdbc.pool.OracleDataSource();
+			ods.setURL("jdbc:oracle:thin:@//<HOST>:<PORT>/<SERVICE_NAME>");
+			ods.setUser("aqjmsuser");
+			ods.setPassword("Welcome_123#");
+			jakarta.jms.TopicConnectionFactory cf = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(ods);
+			jakarta.jms.TopicConnection jmsConn = cf.createTopicConnection();
+			jakarta.jms.Session jmsSession = jmsConn.createTopicSession(true, jakarta.jms.Session.CLIENT_ACKNOWLEDGE);
+			jakarta.jms.Topic topicIn = jmsSession.createTopic("TOPIC_IN");
+			jakarta.jms.MessageConsumer consumer = jmsSession.createDurableSubscriber(topicIn, "Consumer1");			
+			jakarta.jms.Topic topicOut = jmsSession.createTopic("TOPIC_OUT");
+			jakarta.jms.MessageProducer jmsProducer = jmsSession.createProducer(topicOut);			
+			jmsConn.start();
+			jakarta.jms.Message msgConsumed = null;
+			try {
+				msgConsumed = consumer.receive(); 	//Consume message from TOPIC_IN topic
+				java.sql.Connection dbConn = ((oracle.jakarta.jms.AQjmsSession) jmsSession).getDBConnection();				
+				// Perform database operations for consumed message
+				String resultMessage = processMessage(msgConsumed,dbConn);				
+				jakarta.jms.Message msgProduce = jmsSession.createTextMessage("PROCESSED:"+ resultMessage);
+				jmsProducer.send(msgProduce); 	//Send message to TOPIC_OUT 
+				// Commit receive from TOPIC_IN ,Database operation and send to TOPIC_OUT				
+				jmsSession.commit();
+				System.out.println("Successfully Consumed one message from TOPIC_OUT and produced into TOPIC_IN");
+				
+			} catch(Exception e){
+				try {
+					if(msgConsumed != null)
+						jmsSession.rollback();
+				}catch(Exception rollbackE) {}
+			}finally {
+				try {
+					jmsSession.close();         jmsConn.close();
+				}catch(Exception closeE) { }
+			}			
+		} catch (Exception e) { 
+			e.printStackTrace(); 
+		}
+	}
+
+	private static String processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
+	{
+		//Application specific DML Operation using dbConn
+
+		return msg.getBody(String.class);
+	}
+}

--- a/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalConsumer.java
+++ b/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalConsumer.java
@@ -1,0 +1,44 @@
+package com.oracle.jms.example.transactional;
+
+public class JmsTransactionalConsumer {
+	public static void main(String[] args) {
+		try {
+			oracle.jdbc.pool.OracleDataSource ods = new oracle.jdbc.pool.OracleDataSource();
+			ods.setURL("jdbc:oracle:thin:@//<HOST>:<PORT>/<SERVICE_NAME>");
+			ods.setUser("aqjmsuser"); 
+			ods.setPassword("Welcome_123#");
+			jakarta.jms.TopicConnectionFactory cf = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(ods);
+			jakarta.jms.TopicConnection jmsConn = cf.createTopicConnection();
+			jakarta.jms.Session jmsSession = jmsConn.createTopicSession(true, jakarta.jms.Session.CLIENT_ACKNOWLEDGE);
+			jakarta.jms.Topic topic = jmsSession.createTopic("TOPIC_OUT");
+			jakarta.jms.MessageConsumer consumer = jmsSession.createDurableSubscriber(topic, "Consumer1");
+			jmsConn.start();
+			jakarta.jms.Message msg = null;
+			try {   //Consume message from Oracle Transactional Event Queue
+				msg = consumer.receive();
+				java.sql.Connection dbConn =  ((oracle.jakarta.jms.AQjmsSession) jmsSession).getDBConnection();
+				// Perform database operations
+				processMessage(msg,dbConn);
+				// Commit database operation and the consumption of the message
+				jmsSession.commit();
+				System.out.println("Successfully consumed one Message from topic TOPIC_OUT");
+			} catch(Exception e)  {
+				try {
+					if(msg != null)
+						jmsSession.rollback();
+				}catch(Exception rollbackE) {}
+			}finally {
+				try {
+					jmsSession.close();
+					jmsConn.close();
+				}catch(Exception closeE) { }
+			}		
+		} catch (Exception e) { e.printStackTrace(); }
+	}
+
+	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
+	{
+		//Application specific DML Operation 
+
+	}
+}

--- a/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalProducer.java
+++ b/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalProducer.java
@@ -1,0 +1,53 @@
+package com.oracle.jms.example.transactional;
+
+public class JmsTransactionalProducer {
+	public static void main(String[] args) {
+		try {
+			oracle.jdbc.pool.OracleDataSource ods = new oracle.jdbc.pool.OracleDataSource();
+			ods.setURL("jdbc:oracle:thin:@//<HOST>:<PORT>/<SERVICE_NAME>");
+			ods.setUser("aqjmsuser");
+			ods.setPassword("Welcome_123#");
+			jakarta.jms.TopicConnectionFactory cf = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(ods);
+			jakarta.jms.TopicConnection jmsConn = cf.createTopicConnection();
+			jakarta.jms.Session jmsSession = jmsConn.createTopicSession(true, jakarta.jms.Session.CLIENT_ACKNOWLEDGE);
+			jakarta.jms.Topic topic = jmsSession.createTopic("TOPIC_IN");
+			jakarta.jms.MessageProducer jmsProducer = jmsSession.createProducer(topic);
+			jakarta.jms.Message msg = jmsSession.createTextMessage("JMS Test Message");
+			// Get database connection which will be used to produce a message.
+			java.sql.Connection dbConn = ((oracle.jakarta.jms.AQjmsSession)jmsSession).getDBConnection(); 
+			try {
+				// Perform database operations
+				processMessage(msg, dbConn);	
+				// Send a message to Oracle Transactional Event Queue.
+				jmsProducer.send(msg);
+				// Commit Send and database operation
+				jmsSession.commit();      
+				System.out.println("Successfully Produced one Message into topic TOPIC_IN");
+			}catch(Exception e) {
+				try {
+					jmsSession.rollback();
+				}catch(Exception ignoreE) {}
+			}finally {
+				try {
+					jmsSession.close(); 	jmsConn.close();
+				}catch(Exception e) { }
+			}		
+		} catch (Exception e) {
+			System.out.println("Exception " + e);
+			e.printStackTrace(); } 
+	}
+	
+	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
+	{
+		//Application specific DML Operation 
+		
+	}
+	}
+	
+	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
+	{
+		//Application specific DML Operation 
+		
+	}
+
+}


### PR DESCRIPTION
AQ-JMS examples to depict transactional messaging with  database DML operations.
sql/setupTxEQ.sql script creates a database user and sets up the JMS Topics.

JmsTransactionalProducer.java  produces message into TOPIC_IN and also performs a DML operation in the same database transaction.
JmsExactlyOnceConsumeProcessProduce.java consumes message from TOPIC_IN and produces into TOPIC_OUT
JmsTransactionalConsumer.java consumes messages from TOPIC_OUT and performs a DML operation in same transaction. 

