### PR TITLE
AQ JMS Examples with transactional semantics

### DIFF
--- a/txeventq/jms-example/pom.xml
+++ b/txeventq/jms-example/pom.xml
@@ -1,42 +1,38 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"   
-xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0   
-http://maven.apache.org/xsd/maven-4.0.0.xsd">  
- 
-  <modelVersion>4.0.0</modelVersion>  
- 
-  <groupId>com.oracle.jms.example</groupId>  
-  <artifactId>AQ-JMS-Examples</artifactId>  
-  <version>1.0</version>  
-  <packaging>jar</packaging>  
- 
-  <name>AQ JMS Examples</name>  
-  <url>http://maven.apache.org</url>  
- 
-  <dependencies>  
-	<!-- https://mvnrepository.com/artifact/com.oracle.database.messaging/aqapi-jakarta -->
-	<dependency>
-    	<groupId>com.oracle.database.messaging</groupId>
-    	<artifactId>aqapi-jakarta</artifactId>
-   	 	<version>23.3.1.0</version>
-	</dependency>
-	<!-- https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc11 -->
-	<dependency>
-    	<groupId>com.oracle.database.jdbc</groupId>
-    	<artifactId>ojdbc11</artifactId>
-    	<version>23.3.0.23.09</version>
-	</dependency>
-	<!-- https://mvnrepository.com/artifact/jakarta.transaction/jakarta.transaction-api -->
-	<dependency>
-    	<groupId>jakarta.transaction</groupId>
-    	<artifactId>jakarta.transaction-api</artifactId>
-    	<version>2.0.1</version>
-	</dependency>
-	<!-- https://mvnrepository.com/artifact/jakarta.jms/jakarta.jms-api -->
-	<dependency>
-    	<groupId>jakarta.jms</groupId>
-    	<artifactId>jakarta.jms-api</artifactId>
-    	<version>3.1.0</version>
-	</dependency>   
-  </dependencies>    
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  
+ 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0   
+	http://maven.apache.org/xsd/maven-4.0.0.xsd">   
+  	<modelVersion>4.0.0</modelVersion>   
+  	<groupId>com.oracle.jms.example</groupId>  
+  	<artifactId>AQ-JMS-Examples</artifactId>  
+  	<version>1.0</version>  
+  	<packaging>jar</packaging> 
+  	<name>AQ JMS Examples</name>  
+  	<url>http://www.oracle.com</url> 
+ 	<dependencies>  
+		<!-- https://mvnrepository.com/artifact/com.oracle.database.messaging/aqapi-jakarta -->
+		<dependency>
+    		<groupId>com.oracle.database.messaging</groupId>
+    		<artifactId>aqapi-jakarta</artifactId>
+   	 		<version>23.3.1.0</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc11 -->
+		<dependency>
+    		<groupId>com.oracle.database.jdbc</groupId>
+    		<artifactId>ojdbc11</artifactId>
+    		<version>23.3.0.23.09</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/jakarta.transaction/jakarta.transaction-api -->
+		<dependency>
+    		<groupId>jakarta.transaction</groupId>
+    		<artifactId>jakarta.transaction-api</artifactId>
+    		<version>2.0.1</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/jakarta.jms/jakarta.jms-api -->
+		<dependency>
+    		<groupId>jakarta.jms</groupId>
+    		<artifactId>jakarta.jms-api</artifactId>
+    		<version>3.1.0</version>
+		</dependency>   
+  	</dependencies>    
 </project>

--- a/txeventq/jms-example/pom.xml
+++ b/txeventq/jms-example/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"   
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0   
+http://maven.apache.org/xsd/maven-4.0.0.xsd">  
+ 
+  <modelVersion>4.0.0</modelVersion>  
+ 
+  <groupId>com.oracle.jms.example</groupId>  
+  <artifactId>AQ-JMS-Examples</artifactId>  
+  <version>1.0</version>  
+  <packaging>jar</packaging>  
+ 
+  <name>AQ JMS Examples</name>  
+  <url>http://maven.apache.org</url>  
+ 
+  <dependencies>  
+	<!-- https://mvnrepository.com/artifact/com.oracle.database.messaging/aqapi-jakarta -->
+	<dependency>
+    	<groupId>com.oracle.database.messaging</groupId>
+    	<artifactId>aqapi-jakarta</artifactId>
+   	 	<version>23.3.1.0</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc11 -->
+	<dependency>
+    	<groupId>com.oracle.database.jdbc</groupId>
+    	<artifactId>ojdbc11</artifactId>
+    	<version>23.3.0.23.09</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/jakarta.transaction/jakarta.transaction-api -->
+	<dependency>
+    	<groupId>jakarta.transaction</groupId>
+    	<artifactId>jakarta.transaction-api</artifactId>
+    	<version>2.0.1</version>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/jakarta.jms/jakarta.jms-api -->
+	<dependency>
+    	<groupId>jakarta.jms</groupId>
+    	<artifactId>jakarta.jms-api</artifactId>
+    	<version>3.1.0</version>
+	</dependency>   
+  </dependencies>    
+</project>

--- a/txeventq/jms-example/sql/stupTxEQ.sql
+++ b/txeventq/jms-example/sql/stupTxEQ.sql
@@ -1,0 +1,26 @@
+-- Create database user
+create user aqjmsuser identified by Welcome_123#;
+grant connect, resource to aqjmsuser;
+grant execute on dbms_aq to aqjmsuser;
+grant execute on dbms_aqadm to aqjmsuser;
+grant execute on dbms_aqin to aqjmsuser;
+grant unlimited tablespace to aqjmsuser;
+
+-- Create Transactional Event Queue TOPIC_IN and TOPIC_OUT. Add a consumer Consumer1 for both
+Declare
+  subscriber sys.aq$_agent;
+Begin
+   subscriber := sys.aq$_agent('Consumer1', NULL, NULL);
+   dbms_aqadm.create_transactional_event_queue(queue_name=>'aqjmsuser.TOPIC_IN', multiple_consumers=>TRUE);
+   dbms_aqadm.start_queue('aqjmsuser.TOPIC_IN');
+End;
+/
+
+Declare
+  subscriber sys.aq$_agent;
+Begin
+   subscriber := sys.aq$_agent('Consumer1', NULL, NULL);
+   dbms_aqadm.create_transactional_event_queue(queue_name=>'aqjmsuser.TOPIC_OUT', multiple_consumers=>TRUE);
+   dbms_aqadm.start_queue('aqjmsuser.TOPIC_OUT');
+End;
+/

--- a/txeventq/jms-example/sql/stupTxEQ.sql
+++ b/txeventq/jms-example/sql/stupTxEQ.sql
@@ -1,3 +1,10 @@
+/*
+ ** Setup User and Queues for AQ-JMS
+ **
+ ** Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+ */
+
 -- Create database user
 create user aqjmsuser identified by Welcome_123#;
 grant connect, resource to aqjmsuser;

--- a/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsExactlyOnceConsumeProcessProduce.java
+++ b/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsExactlyOnceConsumeProcessProduce.java
@@ -1,0 +1,51 @@
+package com.oracle.jms.example.transactional;
+
+public class JmsExactlyOnceConsumeProcessProduce {
+	public static void main(String[] args) {
+		try {
+			oracle.jdbc.pool.OracleDataSource ods = new oracle.jdbc.pool.OracleDataSource();
+			ods.setURL("jdbc:oracle:thin:@//<HOST>:<PORT>/<SERVICE_NAME>");
+			ods.setUser("aqjmsuser");
+			ods.setPassword("Welcome_123#");
+			jakarta.jms.TopicConnectionFactory cf = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(ods);
+			jakarta.jms.TopicConnection jmsConn = cf.createTopicConnection();
+			jakarta.jms.Session jmsSession = jmsConn.createTopicSession(true, jakarta.jms.Session.CLIENT_ACKNOWLEDGE);
+			jakarta.jms.Topic topicIn = jmsSession.createTopic("TOPIC_IN");
+			jakarta.jms.MessageConsumer consumer = jmsSession.createDurableSubscriber(topicIn, "Consumer1");			
+			jakarta.jms.Topic topicOut = jmsSession.createTopic("TOPIC_OUT");
+			jakarta.jms.MessageProducer jmsProducer = jmsSession.createProducer(topicOut);			
+			jmsConn.start();
+			jakarta.jms.Message msgConsumed = null;
+			try {
+				msgConsumed = consumer.receive(); 	//Consume message from TOPIC_IN topic
+				java.sql.Connection dbConn = ((oracle.jakarta.jms.AQjmsSession) jmsSession).getDBConnection();				
+				// Perform database operations for consumed message
+				String resultMessage = processMessage(msgConsumed,dbConn);				
+				jakarta.jms.Message msgProduce = jmsSession.createTextMessage("PROCESSED:"+ resultMessage);
+				jmsProducer.send(msgProduce); 	//Send message to TOPIC_OUT 
+				// Commit receive from TOPIC_IN ,Database operation and send to TOPIC_OUT				
+				jmsSession.commit();
+				System.out.println("Successfully Consumed one message from TOPIC_OUT and produced into TOPIC_IN");
+				
+			} catch(Exception e){
+				try {
+					if(msgConsumed != null)
+						jmsSession.rollback();
+				}catch(Exception rollbackE) {}
+			}finally {
+				try {
+					jmsSession.close();         jmsConn.close();
+				}catch(Exception closeE) { }
+			}			
+		} catch (Exception e) { 
+			e.printStackTrace(); 
+		}
+	}
+
+	private static String processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
+	{
+		//Application specific DML Operation using dbConn
+
+		return msg.getBody(String.class);
+	}
+}

--- a/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsExactlyOnceConsumeProcessProduce.java
+++ b/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsExactlyOnceConsumeProcessProduce.java
@@ -1,3 +1,10 @@
+/*
+ ** JMS Exactly-Once processing.
+ **
+ ** Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+ */
+
 package com.oracle.jms.example.transactional;
 
 public class JmsExactlyOnceConsumeProcessProduce {
@@ -6,7 +13,7 @@ public class JmsExactlyOnceConsumeProcessProduce {
 			oracle.jdbc.pool.OracleDataSource ods = new oracle.jdbc.pool.OracleDataSource();
 			ods.setURL("jdbc:oracle:thin:@//<HOST>:<PORT>/<SERVICE_NAME>");
 			ods.setUser("aqjmsuser");
-			ods.setPassword("Welcome_123#");
+			ods.setPassword("<PASSWORD>");  // Password for aqjmsuser
 			jakarta.jms.TopicConnectionFactory cf = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(ods);
 			jakarta.jms.TopicConnection jmsConn = cf.createTopicConnection();
 			jakarta.jms.Session jmsSession = jmsConn.createTopicSession(true, jakarta.jms.Session.CLIENT_ACKNOWLEDGE);
@@ -28,23 +35,40 @@ public class JmsExactlyOnceConsumeProcessProduce {
 				System.out.println("Successfully Consumed one message from TOPIC_OUT and produced into TOPIC_IN");
 				
 			} catch(Exception e){
+				System.out.println("Exception while consuming, processing or producing JMS Message: " + e);
+				e.printStackTrace();
 				try {
-					if(msgConsumed != null)
+					if(msgConsumed != null) {
 						jmsSession.rollback();
-				}catch(Exception rollbackE) {}
+					}
+				}catch(Exception rollbackE) {
+					System.out.println("Exception during rollback : " + rollbackE);
+					rollbackE.printStackTrace();
+				}
 			}finally {
 				try {
-					jmsSession.close();         jmsConn.close();
-				}catch(Exception closeE) { }
+					jmsSession.close();
+				}catch(Exception closeE) {
+					System.out.println("Exception while clossing JMS Session: " + closeE);
+					closeE.printStackTrace();
+				}
+				try {
+					jmsConn.close();
+				}catch(Exception closeE) {
+					System.out.println("Exception while clossing JMS Connection: " + closeE);
+					closeE.printStackTrace();
+				}
 			}			
 		} catch (Exception e) { 
+			System.out.println("Exception while setting up JMS Consumer and JMS Producer: " + e);
 			e.printStackTrace(); 
 		}
 	}
 
 	private static String processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
 	{
-		//Application specific DML Operation using dbConn
+		//Application specific DML Operation using dbConn. 
+		//Intentionally left blank
 
 		return msg.getBody(String.class);
 	}

--- a/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalConsumer.java
+++ b/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalConsumer.java
@@ -1,0 +1,45 @@
+package com.oracle.jms.example.transactional;
+
+public class JmsTransactionalConsumer {
+	
+	public static void main(String[] args) {
+		try {
+			oracle.jdbc.pool.OracleDataSource ods = new oracle.jdbc.pool.OracleDataSource();
+			ods.setURL("jdbc:oracle:thin:@//<HOST>:<PORT>/<SERVICE_NAME>");
+			ods.setUser("aqjmsuser"); 
+			ods.setPassword("Welcome_123#");
+			jakarta.jms.TopicConnectionFactory cf = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(ods);
+			jakarta.jms.TopicConnection jmsConn = cf.createTopicConnection();
+			jakarta.jms.Session jmsSession = jmsConn.createTopicSession(true, jakarta.jms.Session.CLIENT_ACKNOWLEDGE);
+			jakarta.jms.Topic topic = jmsSession.createTopic("TOPIC_OUT");
+			jakarta.jms.MessageConsumer consumer = jmsSession.createDurableSubscriber(topic, "Consumer1");
+			jmsConn.start();
+			jakarta.jms.Message msg = null;
+			try {   //Consume message from Oracle Transactional Event Queue
+				msg = consumer.receive();
+				java.sql.Connection dbConn =  ((oracle.jakarta.jms.AQjmsSession) jmsSession).getDBConnection();
+				// Perform database operations
+				processMessage(msg,dbConn);
+				// Commit database operation and the consumption of the message
+				jmsSession.commit();
+				System.out.println("Successfully consumed one Message from topic TOPIC_OUT");
+			} catch(Exception e)  {
+				try {
+					if(msg != null)
+						jmsSession.rollback();
+				}catch(Exception rollbackE) {}
+			}finally {
+				try {
+					jmsSession.close();
+					jmsConn.close();
+				}catch(Exception closeE) { }
+			}		
+		} catch (Exception e) { e.printStackTrace(); }
+	}
+
+	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
+	{
+		//Application specific DML Operation 
+
+	}
+}

--- a/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalConsumer.java
+++ b/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalConsumer.java
@@ -1,3 +1,10 @@
+/*
+ ** JMS Transactional Consumer example
+ **
+ ** Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+ */
+
 package com.oracle.jms.example.transactional;
 
 public class JmsTransactionalConsumer {
@@ -7,7 +14,7 @@ public class JmsTransactionalConsumer {
 			oracle.jdbc.pool.OracleDataSource ods = new oracle.jdbc.pool.OracleDataSource();
 			ods.setURL("jdbc:oracle:thin:@//<HOST>:<PORT>/<SERVICE_NAME>");
 			ods.setUser("aqjmsuser"); 
-			ods.setPassword("Welcome_123#");
+			ods.setPassword("<PASSWORD>");  // Password for aqjmsuser
 			jakarta.jms.TopicConnectionFactory cf = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(ods);
 			jakarta.jms.TopicConnection jmsConn = cf.createTopicConnection();
 			jakarta.jms.Session jmsSession = jmsConn.createTopicSession(true, jakarta.jms.Session.CLIENT_ACKNOWLEDGE);
@@ -15,7 +22,8 @@ public class JmsTransactionalConsumer {
 			jakarta.jms.MessageConsumer consumer = jmsSession.createDurableSubscriber(topic, "Consumer1");
 			jmsConn.start();
 			jakarta.jms.Message msg = null;
-			try {   //Consume message from Oracle Transactional Event Queue
+			try {
+				//Consume message from Oracle Transactional Event Queue
 				msg = consumer.receive();
 				java.sql.Connection dbConn =  ((oracle.jakarta.jms.AQjmsSession) jmsSession).getDBConnection();
 				// Perform database operations
@@ -24,22 +32,40 @@ public class JmsTransactionalConsumer {
 				jmsSession.commit();
 				System.out.println("Successfully consumed one Message from topic TOPIC_OUT");
 			} catch(Exception e)  {
+				System.out.println("Exception while consuming JMS Message: "+ e);
+				e.printStackTrace();
 				try {
-					if(msg != null)
+					if(msg != null) {
 						jmsSession.rollback();
-				}catch(Exception rollbackE) {}
+					}
+				}catch(Exception rollbackE) {
+					System.out.println("Exception during rollback of consumed message: " + rollbackE);
+					rollbackE.printStackTrace();
+				}
 			}finally {
 				try {
 					jmsSession.close();
+				}catch(Exception closeE) {
+					System.out.println("Exception while clossing JMS Session: " + closeE);
+					closeE.printStackTrace();
+				}
+				try {
 					jmsConn.close();
-				}catch(Exception closeE) { }
+				}catch(Exception closeE) {
+					System.out.println("Exception while clossing JMS Connection: " + closeE);
+					closeE.printStackTrace();
+				}
 			}		
-		} catch (Exception e) { e.printStackTrace(); }
+		} catch (Exception e) {
+			System.out.println("Exception while setting up JMS Consumer: " + e);
+			e.printStackTrace();
+			}
 	}
 
 	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
 	{
 		//Application specific DML Operation 
+		//Intentionally left blank
 
 	}
 }

--- a/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalProducer.java
+++ b/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalProducer.java
@@ -1,3 +1,10 @@
+/*
+ ** JMS Transactional Producer example
+ **
+ ** Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+ */
+
 package com.oracle.jms.example.transactional;
 
 public class JmsTransactionalProducer {
@@ -6,7 +13,7 @@ public class JmsTransactionalProducer {
 			oracle.jdbc.pool.OracleDataSource ods = new oracle.jdbc.pool.OracleDataSource();
 			ods.setURL("jdbc:oracle:thin:@//<HOST>:<PORT>/<SERVICE_NAME>");
 			ods.setUser("aqjmsuser");
-			ods.setPassword("Welcome_123#");
+			ods.setPassword("<PASSWORD>");  // Password for aqjmsuser
 			jakarta.jms.TopicConnectionFactory cf = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(ods);
 			jakarta.jms.TopicConnection jmsConn = cf.createTopicConnection();
 			jakarta.jms.Session jmsSession = jmsConn.createTopicSession(true, jakarta.jms.Session.CLIENT_ACKNOWLEDGE);
@@ -24,30 +31,38 @@ public class JmsTransactionalProducer {
 				jmsSession.commit();      
 				System.out.println("Successfully Produced one Message into topic TOPIC_IN");
 			}catch(Exception e) {
+				System.out.println("Exception while producing a message: " + e);
+				e.printStackTrace();
 				try {
 					jmsSession.rollback();
-				}catch(Exception ignoreE) {}
+				}catch(Exception rollbackE) {
+					System.out.println("Exception during rollback of JMS Session. " + rollbackE);
+					rollbackE.printStackTrace();
+				}
 			}finally {
 				try {
-					jmsSession.close(); 	jmsConn.close();
-				}catch(Exception e) { }
+					jmsSession.close();
+				}catch(Exception closeE) {
+					System.out.println("Exception while clossing JMS Session: " + closeE);
+					closeE.printStackTrace();
+				}
+				try {
+					jmsConn.close();
+				}catch(Exception closeE) {
+					System.out.println("Exception while clossing JMS Connection: " + closeE);
+					closeE.printStackTrace();
+				}
 			}		
 		} catch (Exception e) {
-			System.out.println("Exception " + e);
-			e.printStackTrace(); } 
-	}
-	
-	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
-	{
-		//Application specific DML Operation 
-		
-	}
-	}
-	
-	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
-	{
-		//Application specific DML Operation 
-		
+			System.out.println("Exception while setting up JMS Producer" + e);
+			e.printStackTrace();
+		} 
 	}
 
+	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
+	{
+		//Application specific DML Operation 
+		//Intentionally left blank
+
+	}
 }

--- a/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalProducer.java
+++ b/txeventq/jms-example/src/main/java/com/oracle/jms/example/transactional/JmsTransactionalProducer.java
@@ -1,0 +1,53 @@
+package com.oracle.jms.example.transactional;
+
+public class JmsTransactionalProducer {
+	public static void main(String[] args) {
+		try {
+			oracle.jdbc.pool.OracleDataSource ods = new oracle.jdbc.pool.OracleDataSource();
+			ods.setURL("jdbc:oracle:thin:@//<HOST>:<PORT>/<SERVICE_NAME>");
+			ods.setUser("aqjmsuser");
+			ods.setPassword("Welcome_123#");
+			jakarta.jms.TopicConnectionFactory cf = oracle.jakarta.jms.AQjmsFactory.getTopicConnectionFactory(ods);
+			jakarta.jms.TopicConnection jmsConn = cf.createTopicConnection();
+			jakarta.jms.Session jmsSession = jmsConn.createTopicSession(true, jakarta.jms.Session.CLIENT_ACKNOWLEDGE);
+			jakarta.jms.Topic topic = jmsSession.createTopic("TOPIC_IN");
+			jakarta.jms.MessageProducer jmsProducer = jmsSession.createProducer(topic);
+			jakarta.jms.Message msg = jmsSession.createTextMessage("JMS Test Message");
+			// Get database connection which will be used to produce a message.
+			java.sql.Connection dbConn = ((oracle.jakarta.jms.AQjmsSession)jmsSession).getDBConnection(); 
+			try {
+				// Perform database operations
+				processMessage(msg, dbConn);	
+				// Send a message to Oracle Transactional Event Queue.
+				jmsProducer.send(msg);
+				// Commit Send and database operation
+				jmsSession.commit();      
+				System.out.println("Successfully Produced one Message into topic TOPIC_IN");
+			}catch(Exception e) {
+				try {
+					jmsSession.rollback();
+				}catch(Exception ignoreE) {}
+			}finally {
+				try {
+					jmsSession.close(); 	jmsConn.close();
+				}catch(Exception e) { }
+			}		
+		} catch (Exception e) {
+			System.out.println("Exception " + e);
+			e.printStackTrace(); } 
+	}
+	
+	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
+	{
+		//Application specific DML Operation 
+		
+	}
+	}
+	
+	private static void processMessage(jakarta.jms.Message msg, java.sql.Connection dbConn) throws Exception
+	{
+		//Application specific DML Operation 
+		
+	}
+
+}


### PR DESCRIPTION
AQ-JMS examples to depict transactional messaging with database DML operations.
sql/setupTxEQ.sql script creates a database user and sets up the JMS Topics.

JmsTransactionalProducer.java produces message into TOPIC_IN and also performs a DML operation in the same database transaction.
JmsExactlyOnceConsumeProcessProduce.java consumes message from TOPIC_IN and produces into TOPIC_OUT
JmsTransactionalConsumer.java consumes messages from TOPIC_OUT and performs a DML operation in same transaction.

pom.xml files depicts the jar dependencies for the examples.